### PR TITLE
docs: fix typos

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -23,7 +23,7 @@ The full Code applies to all University of Vermont personnel. Personnel includes
 ### What is Wrongdoing?
 Real or suspected violations of legal and regulatory requirements (laws, acts, statutes, regulations), policies and procedures, and/or professional standards. Fraudulent or dishonest conduct resulting in violation of law or University policy.
 
-### Artifical Intelligence Usage
+### Artificial Intelligence Usage
 While it is not explicitly said that there should not be any AI generated code being used, it is encouraged that AI only be used for research and understanding purpose only. It hinders the coders that are using AI generated code from learning and may be wrong anyway. There should be only original code or cited code being used for the contributions being made by developers. 
 
 ### Compliance Reporting System
@@ -43,7 +43,7 @@ Above and beyond the requirements from the University of Vermont Code of Conduct
 We strive to be a community that welcomes and supports people of all backgrounds and identities. This includes, but is not limited to members of any race, ethnicity, culture, national origin, colour, immigration status, social and economic class, educational level, sex, sexual orientation, gender identity and expression, age, size, family status, political belief, religion, and mental and physical ability.
 
 ### Be friendly and patient
-We are a group of students, professionals, researchs, volunteers all with different amounts of time to give, expertise and lives that influence each of us. Take a second to be curious, not judgemental and reach out to help rather than critisize.
+We are a group of students, professionals, researchers, volunteers all with different amounts of time to give, expertise and lives that influence each of us. Take a second to be curious, not judgemental and reach out to help rather than criticize.
 
 ### Be considerate
 Your work will be used by other people, and you in turn will depend on the work of others. Any decision you take will affect users and colleagues, and you should take those consequences into account when making decisions. Remember that we're a world-wide community, so you might not be communicating in someone else's primary language.
@@ -63,7 +63,7 @@ Do not insult or put down other participants. Harassment and other exclusionary 
 Repeated harassment of others. In general, if someone asks you to stop, then stop.
 
 ### When we disagree, try to understand why
-Disagreements, both social and technical, happen all the time and this community is no exception. It is important that we resolve disagreements and differing views constructively. Being unable to understand why someone holds a viewpoint doesn’t mean that they’re wrong and insteadd focus on helping to resolve issues to advance the common goals (like fixing an issues to help users) and learning from mistakes.
+Disagreements, both social and technical, happen all the time and this community is no exception. It is important that we resolve disagreements and differing views constructively. Being unable to understand why someone holds a viewpoint doesn’t mean that they’re wrong and instead focus on helping to resolve issues to advance the common goals (like fixing an issues to help users) and learning from mistakes.
 
 ### Ask for help when unsure
 Nobody is expected to be perfect in this community. Asking questions early avoids many problems later, so questions are encouraged, though they may be directed to the appropriate forum. Those who are asked should be responsive and helpful. 

--- a/docs/concepts/version_control.md
+++ b/docs/concepts/version_control.md
@@ -1,16 +1,16 @@
 # Version Control
 
-Defintion
+Definition
 "A version control system, or VCS, tracks the history of changes as people and teams collaborate on projects together. As developers make changes to the project, 
 any earlier version of the project can be recovered at any time." -Github
 
 Purpose:
-The purpose of a version control system is to provide a historical log of any commits made on the code and to provide an enviroment that faciliates group collaboration
+The purpose of a version control system is to provide a historical log of any commits made on the code and to provide an environment that facilitates group collaboration
 
 Benefits:
 Detailed log of any changes made to the code including who made a change and what changes were made
 Allows groups to work on the same code 
-Allows revisting previous code commits 
+Allows revisiting previous code commits 
 Provides branching option, which allows for working and testing without it effect everyone else
 
 Types of Version Control Systems:

--- a/docs/tools/git.md
+++ b/docs/tools/git.md
@@ -84,7 +84,7 @@ Commonly used options:
 
 - `-m <message>` - Add a message to the commit
 - `-a` - Automatically stage tracked files that have been modified or deleted
-- `--ammend` - Redo the last commit, amending the commit message or the committed files
+- `--amend` - Redo the last commit, amending the commit message or the committed files
 
 :::tip
 Making many smaller commits with meaningful messages is often easier for contributors than fewer large commits.


### PR DESCRIPTION
Fixed a few minor Typos across concepts, tools, and the code of conduct pages. 